### PR TITLE
feat(admin): add navigation bar for admin panel

### DIFF
--- a/admin/create.php
+++ b/admin/create.php
@@ -1,7 +1,6 @@
 <?php
 require_once 'auth_check.php';
 ?>
-
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -11,18 +10,14 @@ require_once 'auth_check.php';
     <link rel="stylesheet" href="style.css">
     <style>
         body { display: block; }
-        .dashboard-header { background-color: var(--card); padding: 15px 30px; border-bottom: 1px solid var(--border); }
-        .dashboard-header h1 { margin: 0; font-size: 22px; }
         .form-container { max-width: 800px; margin: 30px auto; padding: 30px; background: var(--card); border-radius: 8px; box-shadow: 0 4px 12px rgba(0,0,0,0.1); }
         textarea { min-height: 250px; resize: vertical; }
     </style>
 </head>
 <body>
-    <header class="dashboard-header">
-        <h1>Create New Post</h1>
-    </header>
-
+    <?php include 'nav.php'; ?>
     <main class="form-container">
+        <h1>Create New Post</h1>
         <form action="actions.php" method="post">
             <input type="hidden" name="action" value="create">
             <div class="form-group">

--- a/admin/edit.php
+++ b/admin/edit.php
@@ -28,7 +28,6 @@ if ($stmt = $conn->prepare($sql)) {
     $stmt->close();
 }
 ?>
-
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -38,18 +37,14 @@ if ($stmt = $conn->prepare($sql)) {
     <link rel="stylesheet" href="style.css">
     <style>
         body { display: block; }
-        .dashboard-header { background-color: var(--card); padding: 15px 30px; border-bottom: 1px solid var(--border); }
-        .dashboard-header h1 { margin: 0; font-size: 22px; }
         .form-container { max-width: 800px; margin: 30px auto; padding: 30px; background: var(--card); border-radius: 8px; box-shadow: 0 4px 12px rgba(0,0,0,0.1); }
         textarea { min-height: 250px; resize: vertical; }
     </style>
 </head>
 <body>
-    <header class="dashboard-header">
-        <h1>Edit Post</h1>
-    </header>
-
+    <?php include 'nav.php'; ?>
     <main class="form-container">
+        <h1>Edit Post</h1>
         <form action="actions.php" method="post">
             <input type="hidden" name="action" value="update">
             <input type="hidden" name="id" value="<?php echo $post['id']; ?>">

--- a/admin/edit_projects.php
+++ b/admin/edit_projects.php
@@ -1,0 +1,23 @@
+<?php
+require_once 'auth_check.php';
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Edit Projects</title>
+    <link rel="stylesheet" href="style.css">
+    <style>
+        body { display: block; }
+        .content { padding: 30px; }
+    </style>
+</head>
+<body>
+    <?php include 'nav.php'; ?>
+    <main class="content">
+        <h1>Edit Projects</h1>
+        <p>Projects editing interface coming soon.</p>
+    </main>
+</body>
+</html>

--- a/admin/edit_skills.php
+++ b/admin/edit_skills.php
@@ -1,0 +1,23 @@
+<?php
+require_once 'auth_check.php';
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Edit Skills</title>
+    <link rel="stylesheet" href="style.css">
+    <style>
+        body { display: block; }
+        .content { padding: 30px; }
+    </style>
+</head>
+<body>
+    <?php include 'nav.php'; ?>
+    <main class="content">
+        <h1>Edit Skills</h1>
+        <p>Skills editing interface coming soon.</p>
+    </main>
+</body>
+</html>

--- a/admin/index.php
+++ b/admin/index.php
@@ -1,8 +1,7 @@
 <?php
-// Initialize the session and check authentication
 require_once 'auth_check.php';
+require_once '../inc/config.php';
 ?>
-
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -12,11 +11,7 @@ require_once 'auth_check.php';
     <link rel="stylesheet" href="style.css">
     <style>
         body { display: block; }
-        .dashboard-header { background-color: var(--card); padding: 15px 30px; border-bottom: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; }
-        .dashboard-header h1 { margin: 0; font-size: 22px; }
         .dashboard-container { padding: 30px; }
-        .logout-btn { display: inline-block; padding: 8px 15px; background-color: var(--primary); color: white; text-decoration: none; border-radius: 4px; font-weight: 600; transition: background-color 0.2s; }
-        .logout-btn:hover { background-color: var(--primary-hover); }
         .create-btn { display: inline-block; margin-bottom: 20px; padding: 10px 18px; background-color: #28a745; color: white; text-decoration: none; border-radius: 4px; font-weight: 600; }
         .create-btn:hover { background-color: #218838; }
         table { width: 100%; border-collapse: collapse; background: var(--card); box-shadow: 0 4px 12px rgba(0,0,0,0.1); }
@@ -28,16 +23,9 @@ require_once 'auth_check.php';
     </style>
 </head>
 <body>
-    <?php require_once '../inc/config.php'; ?>
-    <header class="dashboard-header">
-        <h1>Manage Blogs</h1>
-        <div>
-            <span style="margin-right: 15px;">Welcome, <strong><?php echo htmlspecialchars($_SESSION["admin_username"]); ?></strong>!</span>
-            <a href="logout.php" class="logout-btn">Logout</a>
-        </div>
-    </header>
-
+    <?php include 'nav.php'; ?>
     <main class="dashboard-container">
+        <h1>Manage Blogs</h1>
         <a href="create.php" class="create-btn">Create New Post</a>
         <table>
             <thead>

--- a/admin/nav.php
+++ b/admin/nav.php
@@ -1,0 +1,15 @@
+<?php // Admin navigation bar ?>
+<nav class="admin-nav">
+  <div class="nav-left">
+    <a href="index.php" class="brand">Admin Panel</a>
+    <ul class="nav-menu">
+      <li><a href="index.php">Manage Blogs</a></li>
+      <li><a href="edit_skills.php">Edit Skills</a></li>
+      <li><a href="edit_projects.php">Edit Projects</a></li>
+    </ul>
+  </div>
+  <div class="nav-right">
+    <span class="welcome">Welcome, <strong><?php echo htmlspecialchars($_SESSION["admin_username"]); ?></strong></span>
+    <a href="logout.php" class="logout-btn">Logout</a>
+  </div>
+</nav>

--- a/admin/style.css
+++ b/admin/style.css
@@ -84,3 +84,58 @@ input[type="password"] {
   text-align: center;
   margin-bottom: 15px;
 }
+
+/* Admin navigation bar */
+.admin-nav {
+  background-color: var(--card);
+  padding: 15px 30px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.admin-nav .brand {
+  font-size: 22px;
+  font-weight: 600;
+  text-decoration: none;
+  color: var(--text);
+  margin-right: 30px;
+}
+
+.admin-nav .nav-menu {
+  list-style: none;
+  display: flex;
+  gap: 15px;
+  margin: 0;
+  padding: 0;
+}
+
+.admin-nav .nav-menu li a {
+  text-decoration: none;
+  color: var(--text);
+  font-weight: 500;
+}
+
+.admin-nav .nav-menu li a:hover {
+  color: var(--primary);
+}
+
+.admin-nav .welcome {
+  margin-right: 15px;
+}
+
+.logout-btn {
+  display: inline-block;
+  padding: 8px 15px;
+  background-color: var(--primary);
+  color: white;
+  text-decoration: none;
+  border-radius: 4px;
+  font-weight: 600;
+  transition: background-color 0.2s;
+}
+
+.logout-btn:hover {
+  background-color: var(--primary-hover);
+}


### PR DESCRIPTION
## Summary
- introduce reusable admin navigation bar with links to blogs, skills and projects management
- add placeholder pages for editing skills and projects
- centralize logout button and navigation styles

## Testing
- `php -l admin/nav.php`
- `php -l admin/edit_skills.php`
- `php -l admin/edit_projects.php`
- `php -l admin/index.php`
- `php -l admin/create.php`
- `php -l admin/edit.php`


------
https://chatgpt.com/codex/tasks/task_e_68af07ffe7b08333b75be7d80d954814