### PR TITLE
Revamp admin CSS and form layouts

### DIFF
--- a/admin/add_project.php
+++ b/admin/add_project.php
@@ -21,25 +21,39 @@ require_once '../inc/config.php';
             <form action="actions.php" method="post">
                 <input type="hidden" name="action" value="add_project">
 
-                <label for="name">Project Name:</label>
-                <input type="text" id="name" name="name" required>
+                <div class="form-group">
+                    <label for="name">Project Name:</label>
+                    <input type="text" id="name" name="name" required>
+                </div>
 
-                <label for="html_url">Project URL:</label>
-                <input type="text" id="html_url" name="html_url" required>
+                <div class="form-group">
+                    <label for="html_url">Project URL:</label>
+                    <input type="text" id="html_url" name="html_url" required>
+                </div>
 
-                <label for="description">Description:</label>
-                <textarea id="description" name="description" rows="4"></textarea>
+                <div class="form-group">
+                    <label for="description">Description:</label>
+                    <textarea id="description" name="description" rows="4"></textarea>
+                </div>
 
-                <label for="language">Language:</label>
-                <input type="text" id="language" name="language">
+                <div class="form-group">
+                    <label for="language">Language:</label>
+                    <input type="text" id="language" name="language">
+                </div>
 
-                <label for="stargazers_count">Star Count:</label>
-                <input type="number" id="stargazers_count" name="stargazers_count" value="0">
+                <div class="form-group">
+                    <label for="stargazers_count">Star Count:</label>
+                    <input type="number" id="stargazers_count" name="stargazers_count" value="0">
+                </div>
 
-                <label for="updated_at">Last Updated:</label>
-                <input type="datetime-local" id="updated_at" name="updated_at" required>
+                <div class="form-group">
+                    <label for="updated_at">Last Updated:</label>
+                    <input type="datetime-local" id="updated_at" name="updated_at" required>
+                </div>
 
-                <button type="submit" class="btn">Add Project</button>
+                <div class="form-group">
+                    <button type="submit" class="btn">Add Project</button>
+                </div>
             </form>
         </section>
     </main>

--- a/admin/create.php
+++ b/admin/create.php
@@ -8,11 +8,6 @@ require_once 'auth_check.php';
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Create New Post</title>
     <link rel="stylesheet" href="style.css">
-    <style>
-        body { display: block; }
-        .form-container { max-width: 800px; margin: 30px auto; padding: 30px; background: var(--card); border-radius: 8px; box-shadow: 0 4px 12px rgba(0,0,0,0.1); }
-        textarea { min-height: 250px; resize: vertical; }
-    </style>
 </head>
 <body>
     <?php include 'nav.php'; ?>
@@ -38,7 +33,7 @@ require_once 'auth_check.php';
             </div>
             <div class="form-group">
                 <button type="submit" class="btn">Create Post</button>
-                <a href="index.php" style="display:inline-block; margin-left: 10px; text-align:center;">Cancel</a>
+                <a href="index.php" class="btn">Cancel</a>
             </div>
         </form>
     </main>

--- a/admin/edit.php
+++ b/admin/edit.php
@@ -35,11 +35,6 @@ if ($stmt = $conn->prepare($sql)) {
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Edit Post</title>
     <link rel="stylesheet" href="style.css">
-    <style>
-        body { display: block; }
-        .form-container { max-width: 800px; margin: 30px auto; padding: 30px; background: var(--card); border-radius: 8px; box-shadow: 0 4px 12px rgba(0,0,0,0.1); }
-        textarea { min-height: 250px; resize: vertical; }
-    </style>
 </head>
 <body>
     <?php include 'nav.php'; ?>
@@ -67,7 +62,7 @@ if ($stmt = $conn->prepare($sql)) {
             </div>
             <div class="form-group">
                 <button type="submit" class="btn">Update Post</button>
-                <a href="index.php" style="display:inline-block; margin-left: 10px; text-align:center;">Cancel</a>
+                <a href="index.php" class="btn">Cancel</a>
             </div>
         </form>
     </main>

--- a/admin/edit_project.php
+++ b/admin/edit_project.php
@@ -40,25 +40,39 @@ if (!$project) {
                 <input type="hidden" name="action" value="update_project">
                 <input type="hidden" name="id" value="<?= $project['id'] ?>">
 
-                <label for="name">Project Name:</label>
-                <input type="text" id="name" name="name" value="<?= htmlspecialchars($project['name']) ?>" required>
+                <div class="form-group">
+                    <label for="name">Project Name:</label>
+                    <input type="text" id="name" name="name" value="<?= htmlspecialchars($project['name']) ?>" required>
+                </div>
 
-                <label for="html_url">Project URL:</label>
-                <input type="text" id="html_url" name="html_url" value="<?= htmlspecialchars($project['html_url']) ?>" required>
+                <div class="form-group">
+                    <label for="html_url">Project URL:</label>
+                    <input type="text" id="html_url" name="html_url" value="<?= htmlspecialchars($project['html_url']) ?>" required>
+                </div>
 
-                <label for="description">Description:</label>
-                <textarea id="description" name="description" rows="4"><?= htmlspecialchars($project['description']) ?></textarea>
+                <div class="form-group">
+                    <label for="description">Description:</label>
+                    <textarea id="description" name="description" rows="4"><?= htmlspecialchars($project['description']) ?></textarea>
+                </div>
 
-                <label for="language">Language:</label>
-                <input type="text" id="language" name="language" value="<?= htmlspecialchars($project['language']) ?>">
+                <div class="form-group">
+                    <label for="language">Language:</label>
+                    <input type="text" id="language" name="language" value="<?= htmlspecialchars($project['language']) ?>">
+                </div>
 
-                <label for="stargazers_count">Star Count:</label>
-                <input type="number" id="stargazers_count" name="stargazers_count" value="<?= (int)$project['stargazers_count'] ?>">
+                <div class="form-group">
+                    <label for="stargazers_count">Star Count:</label>
+                    <input type="number" id="stargazers_count" name="stargazers_count" value="<?= (int)$project['stargazers_count'] ?>">
+                </div>
 
-                <label for="updated_at">Last Updated:</label>
-                <input type="datetime-local" id="updated_at" name="updated_at" value="<?= date('Y-m-d\TH:i', strtotime($project['updated_at'])) ?>" required>
+                <div class="form-group">
+                    <label for="updated_at">Last Updated:</label>
+                    <input type="datetime-local" id="updated_at" name="updated_at" value="<?= date('Y-m-d\TH:i', strtotime($project['updated_at'])) ?>" required>
+                </div>
 
-                <button type="submit" class="btn">Update Project</button>
+                <div class="form-group">
+                    <button type="submit" class="btn">Update Project</button>
+                </div>
             </form>
         </section>
     </main>

--- a/admin/edit_skills.php
+++ b/admin/edit_skills.php
@@ -32,11 +32,20 @@ if ($result->num_rows > 0) {
         <h2>Add New Skill</h2>
         <form action="actions.php" method="post">
             <input type="hidden" name="action" value="add_skill">
-            <label for="name">Skill Name:</label>
-            <input type="text" id="name" name="name" required>
-            <label for="category">Category:</label>
-            <input type="text" id="category" name="category" required>
-            <button type="submit" class="btn">Add Skill</button>
+
+            <div class="form-group">
+                <label for="name">Skill Name:</label>
+                <input type="text" id="name" name="name" required>
+            </div>
+
+            <div class="form-group">
+                <label for="category">Category:</label>
+                <input type="text" id="category" name="category" required>
+            </div>
+
+            <div class="form-group">
+                <button type="submit" class="btn">Add Skill</button>
+            </div>
         </form>
     </section>
 
@@ -72,7 +81,5 @@ if ($result->num_rows > 0) {
         </table>
     </section>
 </main>
-</div> <!--.admin-content-->
-</div> <!--.admin-container-->
 </body>
 </html>

--- a/admin/projects.php
+++ b/admin/projects.php
@@ -27,7 +27,7 @@ if ($result->num_rows > 0) {
             <h1>Manage Projects</h1>
         </div>
 
-        <section class="card">
+        <section class="card action-bar">
             <a href="add_project.php" class="btn">Add New Project</a>
         </section>
 

--- a/admin/style.css
+++ b/admin/style.css
@@ -3,116 +3,35 @@
   --card: #ffffff;
   --text: #333;
   --primary: #007bff;
-  --primary-hover: #0056b3;
   --border: #ddd;
-  --error: #dc3545;
+  --danger: #dc3545;
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-  background-color: var(--bg);
-  color: var(--text);
   margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  background: var(--bg);
+  color: var(--text);
 }
 
-.admin-container {
-  display: flex;
-  min-height: 100vh;
-}
-
+/* navigation */
 .admin-nav {
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
   z-index: 1000;
-}
-
-.admin-content {
-  padding-top: 80px; /* Adjust based on nav height */
-  padding-left: 20px;
-  padding-right: 20px;
-  width: 100%;
-}
-
-.login-card {
   background: var(--card);
-  padding: 30px;
-  border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-  border: 1px solid var(--border);
-}
-
-h1 {
-  text-align: center;
-  margin-bottom: 24px;
-  font-size: 24px;
-}
-
-.form-group {
-  margin-bottom: 15px;
-}
-
-label {
-  display: block;
-  margin-bottom: 5px;
-  font-weight: 600;
-}
-
-input[type="text"],
-input[type="password"] {
-  width: 100%;
-  padding: 10px;
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  box-sizing: border-box;
-}
-
-.btn {
-  width: 100%;
-  padding: 10px;
-  border: none;
-  border-radius: 4px;
-  background-color: var(--primary);
-  color: white;
-  font-size: 16px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-
-.btn:hover {
-  background-color: var(--primary-hover);
-}
-
-.error-message {
-  background-color: #f8d7da;
-  color: var(--error);
-  border: 1px solid #f5c6cb;
-  padding: 10px;
-  border-radius: 4px;
-  text-align: center;
-  margin-bottom: 15px;
-}
-
-/* Admin navigation bar */
-.admin-nav {
-  background-color: var(--card);
-  padding: 15px 30px;
   border-bottom: 1px solid var(--border);
+  padding: 15px 30px;
   display: flex;
   justify-content: space-between;
   align-items: center;
 }
-
-.admin-nav .brand {
-  font-size: 22px;
-  font-weight: 600;
-  text-decoration: none;
-  color: var(--text);
-  margin-right: 30px;
-}
-
 .admin-nav .nav-menu {
   list-style: none;
   display: flex;
@@ -120,110 +39,127 @@ input[type="password"] {
   margin: 0;
   padding: 0;
 }
-
-.admin-nav .nav-menu li a {
+.admin-nav a {
   text-decoration: none;
   color: var(--text);
   font-weight: 500;
 }
-
-.admin-nav .nav-menu li a:hover {
+.admin-nav a:hover {
   color: var(--primary);
 }
-
-.admin-nav .welcome {
-  margin-right: 15px;
-}
-
 .logout-btn {
-  display: inline-block;
   padding: 8px 15px;
-  background-color: var(--primary);
-  color: white;
-  text-decoration: none;
+  background: var(--primary);
+  color: #fff;
   border-radius: 4px;
+  text-decoration: none;
   font-weight: 600;
-  transition: background-color 0.2s;
 }
-
 .logout-btn:hover {
-  background-color: var(--primary-hover);
+  background: #0056b3;
 }
 
-/* Main content styling */
+/* layout */
 .content {
-  padding: 20px;
-  width: 100%;
-  max-width: 1200px;
-  margin: 20px auto;
+  max-width: 1000px;
+  margin: 80px auto 40px;
+  padding: 0 20px;
 }
-
 .content-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
   margin-bottom: 20px;
 }
-
 .card {
   background: var(--card);
-  padding: 20px;
+  border: 1px solid var(--border);
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+  padding: 20px;
   margin-bottom: 20px;
 }
+.action-bar {
+  display: flex;
+  justify-content: flex-end;
+}
+.form-container {
+  max-width: 800px;
+  margin: 80px auto;
+  padding: 20px;
+}
 
+/* forms */
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+.form-group {
+  display: flex;
+  flex-direction: column;
+}
+.form-group label {
+  margin-bottom: 5px;
+  font-weight: 600;
+}
+.form-group input,
+.form-group textarea {
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font: inherit;
+}
+textarea {
+  resize: vertical;
+  min-height: 150px;
+}
+
+/* buttons */
+.btn {
+  display: inline-block;
+  padding: 10px 16px;
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  text-decoration: none;
+  text-align: center;
+  font-weight: 600;
+}
+.btn:hover {
+  background: #0056b3;
+}
+.btn.danger {
+  background: var(--danger);
+}
+.btn.danger:hover {
+  background: #c82333;
+}
+
+/* tables */
 table {
   width: 100%;
   border-collapse: collapse;
-  margin-top: 20px;
 }
-
 th, td {
   padding: 12px;
-  text-align: left;
   border-bottom: 1px solid var(--border);
+  text-align: left;
 }
-
 th {
-  background-color: #f9f9f9;
+  background: #f9f9f9;
   font-weight: 600;
 }
-
-tr:last-child td {
-  border-bottom: none;
+.actions {
+  white-space: nowrap;
+}
+.actions .btn {
+  margin-right: 8px;
 }
 
-tr:hover {
-  background-color: #f5f5f5;
-}
-
-.actions a {
-  margin-right: 10px;
-}
-
-.danger {
-  background-color: var(--error);
-}
-.danger:hover {
-  background-color: #c82333;
-}
-
-form {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-}
-
-form label {
-    margin-bottom: 0;
-}
-
-form input[type="text"] {
-    width: auto;
-    flex-grow: 1;
-}
-
-form .btn {
-    width: auto;
+/* spacing for multiple buttons in a group */
+.form-group .btn + .btn {
+  margin-left: 10px;
 }


### PR DESCRIPTION
## Summary
- Rebuild admin stylesheet from scratch for consistent layout, navigation, forms, buttons, and tables.
- Wrap project, post, and skill forms in `.form-group` containers for cleaner structure and spacing.
- Remove inline styles and fix markup issues across admin pages; align project list header with new action bar.

## Testing
- `php -l admin/add_project.php`
- `php -l admin/create.php`
- `php -l admin/edit_project.php`
- `php -l admin/edit_skills.php`
- `php -l admin/edit.php`
- `php -l admin/projects.php`


------
https://chatgpt.com/codex/tasks/task_e_68b2ee6c984c833395533ecccfbb0a53